### PR TITLE
Tidy fix

### DIFF
--- a/src/Frontend/Modules/Slideshow/Layout/Widgets/Slideshow.tpl
+++ b/src/Frontend/Modules/Slideshow/Layout/Widgets/Slideshow.tpl
@@ -24,7 +24,7 @@
                                 {option:widgetSlideshow.data.link}
                                 </a>
                                 {/option:widgetSlideshow.data.link}
-                                {option:widgetSlideshow.caption}<p class="flex-caption">{$widgetSlideshow.caption}</p>{/option:widgetSlideshow.caption}
+                                {option:widgetSlideshow.caption}<div class="flex-caption">{$widgetSlideshow.caption}</div>{/option:widgetSlideshow.caption}
                             </li>
                         {/iteration:widgetSlideshow}
                         </ul>


### PR DESCRIPTION
Prevent html tidy error: No p element in scope but a p end tag seen.